### PR TITLE
Fix broken Javascript -> action.py RPC calls

### DIFF
--- a/templates/holeyCalibration.html
+++ b/templates/holeyCalibration.html
@@ -100,7 +100,7 @@ var localAction;
 $(document).ready(function() {
 
     $("#acceptCalibration").on('click', function(){
-      action('acceptHoleyCalibrationResults',0,0);
+      action('acceptHoleyCalibrationResults');
       $('#contentModal').modal('toggle');
       return false;
     });

--- a/templates/triangularCalibration.html
+++ b/templates/triangularCalibration.html
@@ -52,7 +52,7 @@
 $(document).ready(function () {
 
     $("#acceptCalibration").on('click', function(){
-      action('acceptTriangularCalibrationResults',0,0);
+      action('acceptTriangularCalibrationResults');
       $('#contentModal').modal('toggle');
       return false;
     });


### PR DESCRIPTION
In my testing, all the updates to `actions.py` with regard to the methods that get called from Javascript seem to be working correctly, except for `acceptTriangleCalibrationResults` and `acceptHoleyCalibrationResults`.  These two invocations were being passed extra parameters to the Python functions, causing a Python exception to get thrown. I simply removed these extra parameters.